### PR TITLE
Add SCION Rust library

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A curated list of awesome SCION tools, applications, libraries and resources.
 - [scion-java-client](https://github.com/netsec-ethz/scion-java-client) - Java SCION application library. :construction:
 
 ##### Rust
-- :lobster: - Rust SCION application library. Work in progress, not yet public. :construction:
+- [scion-rs](https://github.com/MystenLabs/scion-rs) - SCION endhost stack written in Rust.
 
 ##### Bindings
 - [pan-bindings](https://github.com/lschulz/pan-bindings) - C, C++, and Python bindings for pan.


### PR DESCRIPTION
Today we have made our endhost library written in Rust public.

Currently, we have a working UDP socket as well as a raw socket to send and receive SCMP messages (similar features to the snet library). We also have tools to cache and refresh paths via the SCION daemon.

We will continue working on the repository, for example to implement better path management (similar to the pan library), increase resilience, and add a QUIC/SCION socket.

cc @jpcsmith