### PR TITLE
Add NixOS and Operating System Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ A curated list of awesome SCION tools, applications, libraries and resources.
 - [Publications list](https://scion-architecture.net/pages/publications/)
 - [LightningFilter](https://github.com/netsec-ethz/lightning-filter) - High-speed traffic filtering mechanism that performs authentication, rate limiting, and duplicate detection.
 
+## Operating System Support
+- [NixOS Support for SCION](https://wiki.nixos.org/wiki/SCION)
+
 ## License
 
 [![CC0](https://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
I added SCION support to NixOS via https://github.com/NixOS/nixpkgs/pull/298737, which includes a full VM test suite that runs on each commit to Nixpkgs, it's probably worth a mention in this document.